### PR TITLE
Switch flake inputs from local git to GitHub remote

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,17 @@
       "locked": {
         "dir": "flakes/abacusai-fhs",
         "lastModified": 1769338031,
-        "narHash": "sha256-2RzgIPchFsbBuiIrEL1afblvNxnNP49ORA2wSldq9oA=",
-        "ref": "refs/heads/refactor/flake-parts-modular-structure",
-        "rev": "07443a7c05f906abe297c424db2c68191a42af4a",
-        "revCount": 78,
-        "type": "git",
-        "url": "file:./"
+        "narHash": "sha256-bkn+rmC29+beREC/KAKn90/ctaAZNIC5DUd+VvlIGhI=",
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "rev": "766a37b4c7036f3e5a5844f4ea8ca02268d67505",
+        "type": "github"
       },
       "original": {
         "dir": "flakes/abacusai-fhs",
-        "type": "git",
-        "url": "file:./"
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "type": "github"
       }
     },
     "antigravity-fhs": {
@@ -32,17 +32,17 @@
       "locked": {
         "dir": "flakes/antigravity-fhs",
         "lastModified": 1769338031,
-        "narHash": "sha256-2RzgIPchFsbBuiIrEL1afblvNxnNP49ORA2wSldq9oA=",
-        "ref": "refs/heads/refactor/flake-parts-modular-structure",
-        "rev": "07443a7c05f906abe297c424db2c68191a42af4a",
-        "revCount": 78,
-        "type": "git",
-        "url": "file:./"
+        "narHash": "sha256-bkn+rmC29+beREC/KAKn90/ctaAZNIC5DUd+VvlIGhI=",
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "rev": "766a37b4c7036f3e5a5844f4ea8ca02268d67505",
+        "type": "github"
       },
       "original": {
         "dir": "flakes/antigravity-fhs",
-        "type": "git",
-        "url": "file:./"
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "type": "github"
       }
     },
     "antigravity-nix": {
@@ -449,17 +449,17 @@
       "locked": {
         "dir": "flakes/vibe-kanban",
         "lastModified": 1769338031,
-        "narHash": "sha256-2RzgIPchFsbBuiIrEL1afblvNxnNP49ORA2wSldq9oA=",
-        "ref": "refs/heads/refactor/flake-parts-modular-structure",
-        "rev": "07443a7c05f906abe297c424db2c68191a42af4a",
-        "revCount": 78,
-        "type": "git",
-        "url": "file:./"
+        "narHash": "sha256-bkn+rmC29+beREC/KAKn90/ctaAZNIC5DUd+VvlIGhI=",
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "rev": "766a37b4c7036f3e5a5844f4ea8ca02268d67505",
+        "type": "github"
       },
       "original": {
         "dir": "flakes/vibe-kanban",
-        "type": "git",
-        "url": "file:./"
+        "owner": "KostaGorod",
+        "repo": "nix-config",
+        "type": "github"
       }
     },
     "zen-browser": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,9 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 
-    antigravity-fhs.url = "git+file:./?dir=flakes/antigravity-fhs";
-    abacusai-fhs.url = "git+file:./?dir=flakes/abacusai-fhs";
-    vibe-kanban.url = "git+file:./?dir=flakes/vibe-kanban";
+    antigravity-fhs.url = "github:KostaGorod/nix-config?dir=flakes/antigravity-fhs";
+    abacusai-fhs.url = "github:KostaGorod/nix-config?dir=flakes/abacusai-fhs";
+    vibe-kanban.url = "github:KostaGorod/nix-config?dir=flakes/vibe-kanban";
 
     # cosmic-unstable = {
     #   url = "github:lilyinstarlight/nixos-cosmic";


### PR DESCRIPTION
The flake inputs for antigravity-fhs, abacusai-fhs, and vibe-kanban were using local file paths (git+file:./) which fail when the flake is fetched remotely from GitHub. Changed to github: URLs so the flake can be used with commands like:
  nixos-rebuild switch --flake github:KostaGorod/nix-config/main#gpu-node-1