### PR TITLE
fix(ssh-tpm): unbreak FIDO2 askpass and SSH_AUTH_SOCK

### DIFF
--- a/modules/nixos/ssh-tpm-pkcs11.nix
+++ b/modules/nixos/ssh-tpm-pkcs11.nix
@@ -52,8 +52,10 @@ in
     services.gnome.gcr-ssh-agent.enable = lib.mkForce false;
 
     # Set SSH_AUTH_SOCK globally (PAM), so all shells + GUI apps agree.
+    # pam_env requires `${VAR}` syntax; `$VAR` is treated as a literal string
+    # and ends up propagating an unexpanded value into the systemd user env.
     environment.sessionVariables = {
-      SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/ssh-agent";
+      SSH_AUTH_SOCK = "\${XDG_RUNTIME_DIR}/ssh-agent";
       SSH_ASKPASS_REQUIRE = "prefer";
     };
 
@@ -64,6 +66,27 @@ in
       export SSH_ASKPASS="${askpass}/bin/lxqt-openssh-askpass"
       export SSH_ASKPASS_REQUIRE="prefer"
     '';
+
+    # The upstream ssh-agent user unit (from programs.ssh.startAgent) hardcodes
+    # `DISPLAY=fake` and `SSH_ASKPASS=""`, which disables any GUI askpass and
+    # breaks FIDO2 PIN entry for `verify-required` sk keys (the agent silently
+    # treats the missing PIN as an incorrect one and refuses to sign).
+    # Override so the agent uses the real askpass and inherits the display env.
+    # Also tie the lifecycle to graphical-session.target: the default unit is
+    # pulled in by default.target, which activates before cosmic-session
+    # imports DISPLAY/WAYLAND_DISPLAY — so PassEnvironment would otherwise
+    # capture nothing at boot.
+    systemd.user.services.ssh-agent = {
+      wantedBy = lib.mkForce [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
+        Environment = lib.mkForce [
+          "SSH_ASKPASS=${askpass}/bin/lxqt-openssh-askpass"
+          "SSH_ASKPASS_REQUIRE=prefer"
+        ];
+        PassEnvironment = "DISPLAY WAYLAND_DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR";
+      };
+    };
 
     # Add specified users to tss group for TPM access
     users.users = lib.genAttrs cfg.users (_user: {

--- a/users/kosta/programs/shell.nix
+++ b/users/kosta/programs/shell.nix
@@ -19,6 +19,15 @@ _: {
     };
     bashrcExtra = ''
       export PATH="$PATH:$HOME/bin:$HOME/.local/bin"
+
+      # pam_gnome_keyring (enabled for Bitwarden Secret Service) rewrites
+      # SSH_AUTH_SOCK to $XDG_RUNTIME_DIR/keyring/ssh during the PAM session,
+      # but the keyring's ssh component isn't actually started — so the
+      # socket doesn't exist. Restore the path to OpenSSH's agent here so
+      # non-login shells spawned from the graphical session use it.
+      if [ -n "$XDG_RUNTIME_DIR" ]; then
+        export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"
+      fi
     '';
   };
 


### PR DESCRIPTION
## Summary
- `pam_env` needs `${VAR}`; `$VAR` was propagating a literal string into the systemd user env
- ssh-agent user unit was hardcoding `DISPLAY=fake` and blank `SSH_ASKPASS`, killing FIDO2 PIN prompts for `verify-required` sk keys; now tied to `graphical-session.target` with `PassEnvironment` for the display vars
- `pam_gnome_keyring` clobbers `SSH_AUTH_SOCK` with a keyring socket that never exists; `bashrcExtra` re-exports the OpenSSH agent path for non-login shells

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#rocinante`
- [ ] Reboot, log in to Cosmic
- [ ] `systemctl --user show ssh-agent -p Environment -p PassEnvironment` shows the new values
- [ ] `echo $SSH_AUTH_SOCK` in a fresh terminal = `/run/user/1000/ssh-agent`
- [ ] `ssh -v <host>` against a server with sk pubkey authorized → askpass pops on Cosmic, YubiKey blinks, auth succeeds